### PR TITLE
add return value for PostSsoMember method

### DIFF
--- a/Abenity.Api/Abenity.Api.nuspec
+++ b/Abenity.Api/Abenity.Api.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>abenity-csharp</id>
-    <version>1.2.0</version>
+    <version>1.4.0</version>
     <title>abenity csharp</title>
     <authors>Abenity</authors>
     <owners>Abenity, Inc</owners>
@@ -11,7 +11,7 @@
     <iconUrl>http://abenity.s3.amazonaws.com/public-site/images/abenity_logo.gif</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>C# library for communicating with Abenity REST Api</description>
-    <copyright>Copyright 2015</copyright>
+    <copyright>Copyright 2018</copyright>
     <tags>Abenity</tags>
   </metadata>
 </package>

--- a/Abenity.Api/AbenityApi.cs
+++ b/Abenity.Api/AbenityApi.cs
@@ -56,13 +56,13 @@ namespace Abenity.Api
         /// POST to the sso_member.json endpoint.
         /// </summary>
         /// <param name="ssoMemberPayload">The SSO member payload to send to Abenity</param>
-        public void PostSsoMember(SsoMemberPayload ssoMemberPayload)
+        public string PostSsoMember(SsoMemberPayload ssoMemberPayload)
         {
             _ssoMemberPayload = ssoMemberPayload;
-            Post();
+            return Post();
         }
 
-        private void Post()
+        private string Post()
         {
             System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls11 | System.Net.SecurityProtocolType.Tls12;
 
@@ -81,9 +81,14 @@ namespace Abenity.Api
             var receiveStream = response.GetResponseStream();
             var readStream = new StreamReader(receiveStream, Encoding.UTF8);
 
-            Console.WriteLine(readStream.ReadToEnd());
+            string output = readStream.ReadToEnd();
+
             response.Close();
             readStream.Close();
+
+            Console.WriteLine(output);
+
+            return output;
         }
 
         private string GetApiBody()


### PR DESCRIPTION
This is a non breaking change that would add a return value to the PostSsoMember method.  This change keeps the existing write to console functionality while adding a return value for easier use.